### PR TITLE
Add test only set delegation

### DIFF
--- a/app/controllers/testOnly/SetDelegationController.scala
+++ b/app/controllers/testOnly/SetDelegationController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testOnly
+
+import controllers.agent.SessionKeys.*
+import play.api.Logging
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class SetDelegationController @Inject()(
+   val mcc: MessagesControllerComponents
+)(implicit
+  val ec: ExecutionContext
+) extends FrontendController(mcc) with Logging {
+
+  def delegationPage(): Action[AnyContent] = Action { request =>
+    val sessionId = request.session.get("sessionId")
+    val mtditid = request.session.get(clientMTDID)
+    val nino = request.session.get(clientNino) // eg TT217906A
+
+    logger.info(s"[SetDelegationController][setDelegation] Existing MTDITID=$mtditid, NINO=$nino")
+
+    val view = views.html.testOnly.SetDelegation(mtditid.getOrElse(""), nino.getOrElse(""), sessionId.getOrElse("none"))
+    Ok(view)
+  }
+  
+  def setDelegation(): Action[AnyContent] = Action { request =>
+    val data = request.body.asFormUrlEncoded.get
+    val mtditid = data("mtditid").mkString
+    val nino = data("nino").mkString
+
+    logger.info(s"[SetDelegationController][setDelegation] Setting client MTDITID to $mtditid and NINO to $nino")
+
+    val newSession = request.session + (clientMTDID -> mtditid) + (clientNino -> nino)
+    SeeOther(routes.SetDelegationController.delegationPage().url).withSession(newSession)
+  }
+}

--- a/app/controllers/testOnly/SetDelegationController.scala
+++ b/app/controllers/testOnly/SetDelegationController.scala
@@ -19,26 +19,39 @@ package controllers.testOnly
 import controllers.agent.SessionKeys.*
 import play.api.Logging
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
+import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future.successful
 
 class SetDelegationController @Inject()(
-   val mcc: MessagesControllerComponents
+  authConnector: AuthConnector,
+  val mcc: MessagesControllerComponents
 )(implicit
   val ec: ExecutionContext
 ) extends FrontendController(mcc) with Logging {
 
-  def delegationPage(): Action[AnyContent] = Action { request =>
+  def delegationPage(): Action[AnyContent] = Action.async { request =>
     val sessionId = request.session.get("sessionId")
     val mtditid = request.session.get(clientMTDID)
     val nino = request.session.get(clientNino) // eg TT217906A
 
-    logger.info(s"[SetDelegationController][setDelegation] Existing MTDITID=$mtditid, NINO=$nino")
+    mtditid.filterNot(_.isBlank).map { id =>
+      implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+      val spec = Enrolment("HMRC-MTD-IT").withIdentifier("MTDITID",id).withDelegatedAuthRule("mtd-it-auth")
+      authConnector.authorise(spec, EmptyRetrieval).map(_=>"Success").recover(e=>e.getClass.getSimpleName + ": " + e.getMessage)
 
-    val view = views.html.testOnly.SetDelegation(mtditid.getOrElse(""), nino.getOrElse(""), sessionId.getOrElse("none"))
-    Ok(view)
+    }.getOrElse(successful("")).map { authReesult =>
+      logger.info(s"[SetDelegationController][setDelegation] Existing MTDITID=$mtditid, NINO=$nino, auth result: $authReesult")
+
+      val view = views.html.testOnly.SetDelegation(mtditid.getOrElse(""), nino.getOrElse(""), sessionId.getOrElse("none"), authReesult)
+      Ok(view)
+    }
   }
   
   def setDelegation(): Action[AnyContent] = Action { request =>

--- a/app/views/testOnly/SetDelegation.scala.html
+++ b/app/views/testOnly/SetDelegation.scala.html
@@ -1,0 +1,29 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(mtditid: String, nino: String, sessionId: String)
+
+<html>
+ <body>
+   <form method="post">
+    <p>Session ID: @sessionId</p>
+    <p>MTDITID: <input type="text" name="mtditid" value="@mtditid"></p>
+    <p>NINO: <input type="text" name="nino" value="@nino"></p>
+    <p><input type="submit"></p>
+   </form>
+   <p><a href="/income-tax-penalties-frontend/">main page</a></p>
+ </body>
+</html>

--- a/app/views/testOnly/SetDelegation.scala.html
+++ b/app/views/testOnly/SetDelegation.scala.html
@@ -16,12 +16,12 @@
 
 @(mtditid: String, nino: String, sessionId: String)
 
-<html>
+<html lang="en-GB">
  <body>
    <form method="post">
     <p>Session ID: @sessionId</p>
-    <p>MTDITID: <input type="text" name="mtditid" value="@mtditid"></p>
-    <p>NINO: <input type="text" name="nino" value="@nino"></p>
+    <p>MTDITID: <input type="text" name="mtditid" value="@mtditid" aria-label="Making Tax Digital for Income Tax Identifier"></p>
+    <p>NINO: <input type="text" name="nino" value="@nino" aria-label="National Insurance Number"></p>
     <p><input type="submit"></p>
    </form>
    <p><a href="/income-tax-penalties-frontend/">main page</a></p>

--- a/app/views/testOnly/SetDelegation.scala.html
+++ b/app/views/testOnly/SetDelegation.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@(mtditid: String, nino: String, sessionId: String)
+@(mtditid: String, nino: String, sessionId: String, authResult: String)
 
 <html lang="en-GB">
  <body>
@@ -24,6 +24,7 @@
     <p>NINO: <input type="text" name="nino" value="@nino" aria-label="National Insurance Number"></p>
     <p><input type="submit"></p>
    </form>
+   @if(!authResult.isBlank){<p>Auth test result: @authResult</p>}
    <p><a href="/income-tax-penalties-frontend/">main page</a></p>
  </body>
 </html>

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,7 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+GET        /income-tax-penalties/test-only/set-delegation controllers.testOnly.SetDelegationController.delegationPage()
++NOCSRF
+POST       /income-tax-penalties/test-only/set-delegation controllers.testOnly.SetDelegationController.setDelegation()


### PR DESCRIPTION
Enables test workflow:

1. sm2 -start AUTH_LOGIN_API AUTH_LOGIN_STUB AUTH USER_DETAILS ASSETS_FRONTEND_2 IDENTITY_VERIFICATION
2. sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes
3. visit http://localhost:9949/auth-login-stub/gg-sign-in?continue=http://localhost:9185/income-tax-penalties/test-only/set-delegation
4. select agent affinity
5. enter delegated enrollment for HRMC-MTD-IT MTDITID and auth rule mtd-it-auth
6. submit
7. enter the same MTDITID
8. enter a valid test NINO
9. submit
10. click thru to main page