### PR TITLE
[MIPR-1371] Output 'no penalties' message on tab when no penalties exist

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/IndexView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/IndexView.scala.html
@@ -47,38 +47,48 @@
 
     @h3(msg = "general.main.lsp", elmId = "lspHeading")
 
-    <p class="govuk-body-l">@messages("general.main.penalty.point.total") <strong class="govuk-!-font-weight-bold">4</strong></p>
+    @if(lspData.isEmpty) {
+        @p("lsp.noPenalties")
+    } else {
 
-    @warning(msg = individualOrAgent + ".main.warning.text", elmId = "financialWarningText")
+        <p class="govuk-body-l">@messages("general.main.penalty.point.total") <strong class="govuk-!-font-weight-bold">4</strong></p>
 
-    @p(individualOrAgent + ".main.what.this.means")
+        @warning(msg = individualOrAgent + ".main.warning.text", elmId = "financialWarningText")
 
-    @link(
-        link = uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.routes.ComplianceTimelineController.complianceTimelinePage.url,
-        messageKey = messages(individualOrAgent + ".main.actions.to.remove.link") + " " + messages("general.opens.in.new.tab"),
-        attrTarget = true,
-        id = Some("actionsToRemoveLink")
-    )
+        @p(individualOrAgent + ".main.what.this.means")
 
-    @lspData.map { lsp =>
-        @summaryCardLSP(lsp)
+        @link(
+            link = uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.routes.ComplianceTimelineController.complianceTimelinePage.url,
+            messageKey = messages(individualOrAgent + ".main.actions.to.remove.link") + " " + messages("general.opens.in.new.tab"),
+            attrTarget = true,
+            id = Some("actionsToRemoveLink")
+        )
+
+        @lspData.map { lsp =>
+            @summaryCardLSP(lsp)
+        }
     }
 }
 
 @lppMainTab(individualOrAgent: String) = {
     @h3(msg = "general.main.lpp", elmId = "lppHeading")
 
-    @p(individualOrAgent + ".main.pay.early.info")
+    @if(lppData.isEmpty) {
+        @p("lpp.noPenalties")
+    } else {
 
-    @link(
-        link = "#",
-        messageKey = messages("general.main.penalty.summary.guidance.on.late.payments") + " " + messages("general.opens.in.new.tab"),
-        attrTarget = true,
-        id = Some("guidanceLatePaymentLink")
-    )
+        @p(individualOrAgent + ".main.pay.early.info")
 
-    @lppData.map { lpp =>
-        @summaryCardLPP(lpp)
+        @link(
+            link = "#", //TODO: Add link as part of future story,
+            messageKey = messages("general.main.penalty.summary.guidance.on.late.payments") + " " + messages("general.opens.in.new.tab"),
+            attrTarget = true,
+            id = Some("guidanceLatePaymentLink")
+        )
+
+        @lppData.map { lpp =>
+            @summaryCardLPP(lpp)
+        }
     }
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -106,6 +106,7 @@ lsp.updateSubmitted.key = Update submitted
 lsp.updateSubmitted.notReceived = Return not received
 lsp.expiry.key = Point due to expire
 lsp.expiryReason.key = Removed reason
+lsp.noPenalties = There are no late submission penalties.
 
 # Late Payment Penalty - Summary Row Key/Values
 # =============================================
@@ -119,6 +120,7 @@ lpp.incomeTaxPeriod.value = Income Tax for {0} to {1} tax year
 lpp.incomeTaxDue.key = Income Tax due
 lpp.incomeTaxPaymentDate.key = Income Tax paid
 lpp.paymentNotReceived = Payment not yet received
+lpp.noPenalties = There are no late payment penalties.
 
 # Appeal Status
 # =============

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -34,6 +34,7 @@ lsp.updateSubmitted.key = Update submitted (Welsh)
 lsp.updateSubmitted.notReceived = Return not received (Welsh)
 lsp.expiry.key = Point due to expire (Welsh)
 lsp.expiryReason.key = Removed reason (Welsh)
+lsp.noPenalties = There are no late submission penalties. (Welsh)
 
 # Late Payment Penalty - Summary Row Key/Values
 # =============================================
@@ -47,6 +48,7 @@ lpp.incomeTaxPeriod.value = Income Tax for {0} to {1} tax year (Welsh)
 lpp.incomeTaxDue.key = Income Tax due (Welsh)
 lpp.incomeTaxPaymentDate.key = Income Tax paid (Welsh)
 lpp.paymentNotReceived = Payment not yet received (Welsh)
+lpp.noPenalties = There are no late payment penalties. (Welsh)
 
 # Appeal Status
 # =============

--- a/test-fixtures/fixtures/messages/IndexViewMessages.scala
+++ b/test-fixtures/fixtures/messages/IndexViewMessages.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages
+
+object IndexViewMessages {
+
+  sealed trait Messages { _: i18n =>
+    val noLSP = "There are no late submission penalties."
+    val noLPP = "There are no late payment penalties."
+  }
+
+  object English extends Messages with En
+
+  object Welsh extends Messages with Cy {
+    override val noLSP = "There are no late submission penalties. (Welsh)"
+    override val noLPP = "There are no late payment penalties. (Welsh)"
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/views/IndexViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/views/IndexViewSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesfrontend.views
+
+import fixtures.messages.IndexViewMessages
+import org.jsoup.Jsoup
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, MessagesApi}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesfrontend.views.html.IndexView
+
+class IndexViewSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with ScalaFutures {
+
+  lazy val indexView: IndexView = app.injector.instanceOf[IndexView]
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
+  object Selectors {
+    val lspTab = "#lspTab"
+    val lppTab = "#lppTab"
+  }
+
+  "indexView" when {
+
+    Seq(IndexViewMessages.English, IndexViewMessages.Welsh).foreach { messagesForLanguage =>
+
+      implicit val msgs = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
+
+      s"rendering in the language '${messagesForLanguage.lang.name}'" when {
+
+        "there are no Late Submission or Late Payment penalties" should {
+
+          lazy val html = indexView(Seq(), Seq(), isAgent = false)
+          lazy val document = Jsoup.parse(html.toString())
+
+          "render the Late Submission tab with the 'no penalties' message" in {
+            document.select(Selectors.lspTab).select("p").text() shouldBe messagesForLanguage.noLSP
+          }
+
+          "render the Late Payment tab with the 'no penalties' message" in {
+            document.select(Selectors.lppTab).select("p").text() shouldBe messagesForLanguage.noLPP
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Notes:
- #21 needs to be reviewed and merged first, then this branch rebased from `main`
  - this is because this previous story was a dependency for this one.
- Shows a "No penalties" message when no LSP or LPP exist
- Specific changes for this ticket can be view on this commit:  https://github.com/hmrc/income-tax-penalties-frontend/commit/7bef61c0b26d0662328addd91fb72b6119b0606b