### PR TITLE
[MIPR-1654] Add AuditService wrapper to AuditConnector with extendable AuditModel

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/audit/AuditModel.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/audit/AuditModel.scala
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
+package uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit
 
-import play.api.i18n.Messages
+import play.api.libs.json.JsValue
 
-import java.time.LocalDate
-
-trait DateFormatter {
-
-  private val htmlNonBroken: String => String = _.replace(" ", "\u00A0")
-
-  def dateToString(date: LocalDate)(implicit messages: Messages): String =
-    htmlNonBroken(s"${date.getDayOfMonth} ${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
-
-  def dateToMonthYearString(date: LocalDate)(implicit messages: Messages): String =
-    htmlNonBroken(s"${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
+trait AuditModel {
+  val auditType: String
+  val detail: JsValue
 }
-
-object DateFormatter extends DateFormatter

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/services/AuditService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/services/AuditService.scala
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
+package uk.gov.hmrc.incometaxpenaltiesfrontend.services
 
-import play.api.i18n.Messages
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit.AuditModel
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
-import java.time.LocalDate
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
 
-trait DateFormatter {
+class AuditService @Inject()(auditConnector: AuditConnector)(implicit ec: ExecutionContext) {
 
-  private val htmlNonBroken: String => String = _.replace(" ", "\u00A0")
+  def audit(auditModel: AuditModel)(implicit hc: HeaderCarrier): Unit =
+    auditConnector.sendExplicitAudit(auditModel.auditType, auditModel.detail)
 
-  def dateToString(date: LocalDate)(implicit messages: Messages): String =
-    htmlNonBroken(s"${date.getDayOfMonth} ${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
-
-  def dateToMonthYearString(date: LocalDate)(implicit messages: Messages): String =
-    htmlNonBroken(s"${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
 }
-
-object DateFormatter extends DateFormatter

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LPPSummaryListRowHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LPPSummaryListRowHelper.scala
@@ -35,7 +35,7 @@ class LPPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
     penalty.penaltyChargeCreationDate.map { creationDate =>
       summaryListRow(
         label = messages("lpp.addedOn.key"),
-        value = Html(DateFormatter.dateNonBreakingSpaceSingle(dateToString(creationDate)))
+        value = Html(dateToString(creationDate))
       )
     }
 
@@ -52,7 +52,7 @@ class LPPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
   def incomeTaxDueRow(penalty: LPPDetails)(implicit messages: Messages): SummaryListRow =
     summaryListRow(
       label = messages("lpp.incomeTaxDue.key"),
-      value = Html(DateFormatter.dateNonBreakingSpaceSingle(dateToString(penalty.principalChargeDueDate)))
+      value = Html(dateToString(penalty.principalChargeDueDate))
     )
 
   def incomeTaxPaymentDateRow(penalty: LPPDetails)(implicit messages: Messages): SummaryListRow =
@@ -60,7 +60,7 @@ class LPPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
       messages("lpp.incomeTaxPaymentDate.key"),
       Html(
         if (penalty.penaltyStatus.equals(LPPPenaltyStatusEnum.Posted) && penalty.principalChargeLatestClearing.isDefined) {
-          DateFormatter.dateNonBreakingSpaceSingle(dateToString(penalty.principalChargeLatestClearing.get))
+          dateToString(penalty.principalChargeLatestClearing.get)
         } else {
           messages("lpp.paymentNotReceived")
         }

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LSPSummaryListRowHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LSPSummaryListRowHelper.scala
@@ -29,7 +29,7 @@ class LSPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
       case (Some(startDate), Some(endDate)) =>
         Some(summaryListRow(
           label = messages("lsp.quarter.key"),
-          value = Html(DateFormatter.dateNonBreakingSpaceMultiple("lsp.quarter.value", dateToString(startDate), dateToString(endDate)))
+          value = Html(messages("lsp.quarter.value", dateToString(startDate), dateToString(endDate)))
         ))
       case _ => None
     }
@@ -38,7 +38,7 @@ class LSPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
     penalty.dueDate.map { dueDate =>
       summaryListRow(
         label = messages("lsp.updateDue.key"),
-        value = Html(DateFormatter.dateNonBreakingSpaceSingle(dateToString(dueDate)))
+        value = Html(dateToString(dueDate))
       )
     }
 
@@ -61,6 +61,6 @@ class LSPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
   def pointExpiryDate(penalty: LSPDetails)(implicit messages: Messages): SummaryListRow =
     summaryListRow(
       messages("lsp.expiry.key"),
-      Html(DateFormatter.dateNonBreakingSpaceSingle(dateToMonthYearString(penalty.penaltyExpiryDate)))
+      Html(dateToMonthYearString(penalty.penaltyExpiryDate))
     )
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/services/AuditServiceSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesfrontend.services
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{times, verify}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit.AuditModel
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
+import scala.concurrent.ExecutionContext
+
+class AuditServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  val auditConnector: AuditConnector = mock[AuditConnector]
+  val service = new AuditService(auditConnector)
+
+  val testAuditModel: AuditModel = new AuditModel {
+    override val auditType: String = "auditType"
+    override val detail: JsValue = Json.obj("key" -> "value")
+  }
+
+  "AuditService" should {
+
+    "audit an explicit event" in {
+
+      service.audit(testAuditModel)
+
+      verify(auditConnector, times(1)).sendExplicitAudit(
+        auditType = eqTo(testAuditModel.auditType),
+        detail = eqTo(testAuditModel.detail)
+      )(any(), any(), any())
+    }
+  }
+}


### PR DESCRIPTION
**Note**
- Includes a small refactor to the `DateFormatter` to get rid of a compilation warning