### PR TITLE
MIPR-1684: TimeMachine Class

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
@@ -90,11 +90,10 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   lazy val timeMachineDate: String =
     config.get[String]("timemachine.date")
-  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yy")
 
   def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
     Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption
   } else None
-
 
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
@@ -22,7 +22,11 @@ import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.net.URLEncoder
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.{Inject, Singleton}
+import scala.util.Try
+
 
 @Singleton
 class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) extends FeatureSwitching {
@@ -80,4 +84,17 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   }
 
   lazy val enterClientUTRVandCUrl: String = config.get[String]("income-tax-view-change.enterClientUTR.url")
+
+  lazy val timeMachineEnabled: Boolean =
+    config.get[Boolean]("timemachine.enabled")
+
+  lazy val timeMachineDate: String =
+    config.get[String]("timemachine.date")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+  def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
+    Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption
+  } else None
+
+
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/config/AppConfig.scala
@@ -90,7 +90,7 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   lazy val timeMachineDate: String =
     config.get[String]("timemachine.date")
-  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
 
   def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
     Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachine.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachine.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
 
+import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
+
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class TimeMachine @Inject()() {
+class TimeMachine @Inject()(appConfig: AppConfig) {
 
-  def getCurrentDate: LocalDate = LocalDate.now()
+  def getCurrentDate: LocalDate = appConfig.optCurrentDate.getOrElse(LocalDate.now())
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,6 +96,11 @@ tracking-consent-frontend {
   gtm.container = "d"
 }
 
+timemachine{
+    enabled = true
+    date = "now"
+}
+
 contact-frontend.serviceId = "ITSAPR"
 
 alpha-banner-url = "#"

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/services/TimelineBuilderServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/services/TimelineBuilderServiceSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.{DateFormatter, TimeMachine}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.viewModels.TimelineEvent
 
@@ -30,7 +31,7 @@ import java.time.LocalDate
 class TimelineBuilderServiceSpec extends AnyWordSpec with Matchers with ComplianceDataTestData with GuiceOneAppPerSuite with DateFormatter {
 
   class Setup(runDate: LocalDate = LocalDate.of(2023,4,13)) {
-    object FakeTimeMachine extends TimeMachine {
+    object FakeTimeMachine extends TimeMachine(appConfig = app.injector.instanceOf[AppConfig]) {
       override def getCurrentDate: LocalDate = runDate
     }
     val service: TimelineBuilderService = new TimelineBuilderService(FakeTimeMachine)

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
@@ -1,0 +1,5 @@
+package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
+
+class TimeMachineSpec {
+
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
@@ -1,5 +1,48 @@
 package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
 
-class TimeMachineSpec {
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.inject.guice.GuiceApplicationBuilder
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class TimeMachineSpec extends AnyWordSpec with Matchers{
+
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+
+
+  "TimeMachine -getCurrentDate" should {
+
+    "Return the configured date specified" in {
+      val app = new GuiceApplicationBuilder().configure(
+        "timemachine.enabled" -> true,
+        "timemachine.date" -> "01-01-2021"
+      ).build()
+
+      val timeMachine = app.injector.instanceOf[TimeMachine]
+      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-2021", dateFormatter)
+    }
+  }
+
+  "Return the current date if timemachine is disabled" in {
+    val app = new GuiceApplicationBuilder().configure(
+      "timemachine.enabled" -> false
+    ).build()
+
+    val timeMachine = app.injector.instanceOf[TimeMachine]
+    timeMachine.getCurrentDate shouldEqual LocalDate.now()
+  }
+
+  "Return the current date if timemachine date set to now" in {
+
+    val app = new GuiceApplicationBuilder().configure(
+      "timemachine.enabled" -> true,
+      "timemachine.date" -> "now"
+    ).build()
+
+    val timeMachine = app.injector.instanceOf[TimeMachine]
+    timeMachine.getCurrentDate shouldEqual LocalDate.now()
+
+  }
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/utils/TimeMachineSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.incometaxpenaltiesfrontend.utils
 
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +25,7 @@ import java.time.format.DateTimeFormatter
 
 class TimeMachineSpec extends AnyWordSpec with Matchers{
 
-  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yy")
 
 
   "TimeMachine -getCurrentDate" should {
@@ -17,11 +33,11 @@ class TimeMachineSpec extends AnyWordSpec with Matchers{
     "Return the configured date specified" in {
       val app = new GuiceApplicationBuilder().configure(
         "timemachine.enabled" -> true,
-        "timemachine.date" -> "01-01-2021"
+        "timemachine.date" -> "01-01-21"
       ).build()
 
       val timeMachine = app.injector.instanceOf[TimeMachine]
-      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-2021", dateFormatter)
+      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-21", dateFormatter)
     }
   }
 


### PR DESCRIPTION
Update application.conf file to contain:
- [ ]  A timemachine.enabled flag
- [ ]  A timemachine.date String field (all for “now” or string date of format dd/mm/yy“)

Create a new TimeMachineConfig file (or update appConfig) and add:
- [ ] A function to get the optCurrentDate – i.e (if(timemachine is enabled && timemachineDate != “now”) { Parse date string to date and return} else return None

Update the Timemachine class to get the optCurrentDate or use the java current date