### PR TITLE
MIPR-1992 updated view so correct appeal links show

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/PenaltyCalculationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/PenaltyCalculationController.scala
@@ -20,9 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.auth.actions.AuthActions
-import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.auth.models.AuthenticatedUserWithPenaltyData
 import uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit.UserCalculationInfoAuditModel
-import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp.LPPDetails
 import uk.gov.hmrc.incometaxpenaltiesfrontend.services.AuditService
 import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesfrontend.viewModels._

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/audit/UserComplianceInfoAuditModel.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/audit/UserComplianceInfoAuditModel.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit
 
 import play.api.libs.json.{JsValue, Json, Writes}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.auth.models.CurrentUserRequest
-import uk.gov.hmrc.incometaxpenaltiesfrontend.models.ITSAStatus.ITSAStatus
 import uk.gov.hmrc.incometaxpenaltiesfrontend.models.compliance.ObligationDetail
 
 case class UserComplianceInfoAuditModel(isMTDMandated: Boolean,

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/penaltyDetails/lpp/LPPDetails.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/models/penaltyDetails/lpp/LPPDetails.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp
 
 import play.api.libs.json._
-import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.JsonUtils
-import LPPPenaltyStatusEnum.Posted
 import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.appealInfo.{AppealInformationType, AppealLevelEnum, AppealStatusEnum}
+import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp.LPPPenaltyStatusEnum.Posted
+import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.JsonUtils
 
 import java.time.LocalDate
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/Lpp2Calculation.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/Lpp2Calculation.scala.html
@@ -35,8 +35,6 @@
 
 @(calculationData: SecondLatePaymentPenaltyCalculationData, isAgent: Boolean)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@individualOrAgent = {@if(isAgent){agent}else{individual}}
-
 @main(pageTitle = messages(s"calculation.individual.second.title"), backLinkEnabled = true, isAgent = isAgent) {
 
     <span class="govuk-caption-l" id="captionSpan">

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLPP.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLPP.scala.html
@@ -55,31 +55,21 @@
                             {messages("cardLinks.viewCalculation")}
                         </a>
                     </li>
-                    {if(summaryCard.incomeTaxIsPaid || summaryCard.isTTPActive) {
-                        if(summaryCard.penaltyChargeReference.isDefined) {
-                            summaryCard.appealStatus match {
-                                case Some(AppealStatusEnum.Rejected) if summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal) =>
-                                    <li class="govuk-summary-card__action no-border not-bold">
-                                        <a id={"lpp-appeal-link-" + summaryCard.index} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyChargeReference.get, isAgent, isLPP = true, isLPP2 = summaryCard.penaltyCategory.equals(LPP2), is2ndStageAppeal = summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal)).url}>
-                                            {messages("cardLinks.reviewAppeal")}
-                                        </a>
-                                    </li>
-                                case None =>
-                                    <li class="govuk-summary-card__action no-border not-bold">
-                                        <a id={"lpp-appeal-link-" + summaryCard.index} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyChargeReference.get, isAgent, isLPP = true, isLPP2 = summaryCard.penaltyCategory.equals(LPP2)).url}>
-                                            {messages("cardLinks.checkIfYouCanAppealThisPenalty")}
-                                        </a>
-                                    </li>
-                                case _ =>
-                            }
-                        }
-                    } else {
-                        if(summaryCard.appealStatus.isEmpty) {
-                            <li class="govuk-summary-card__action no-border not-bold">
-                                <a id={"lpp-appeal-link-" + summaryCard.index} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyChargeReference.get, isAgent, isLPP = true, isLPP2 = summaryCard.penaltyCategory.equals(LPP2)).url}>
-                                    {messages("cardLinks.checkIfYouCanAppealThisPenalty")}
-                                </a>
-                            </li>
+                    {if(summaryCard.penaltyChargeReference.isDefined) {
+                        summaryCard.appealStatus match {
+                            case Some(AppealStatusEnum.Rejected) if summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal) =>
+                                <li class="govuk-summary-card__action no-border not-bold">
+                                    <a id={"lpp-appeal-link-" + summaryCard.index} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyChargeReference.get, isAgent, isLPP = true, isLPP2 = summaryCard.penaltyCategory.equals(LPP2), is2ndStageAppeal = summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal)).url}>
+                                        {messages("cardLinks.reviewAppeal")}
+                                    </a>
+                                </li>
+                            case None =>
+                                <li class="govuk-summary-card__action no-border not-bold">
+                                    <a id={"lpp-appeal-link-" + summaryCard.index} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyChargeReference.get, isAgent, isLPP = true, isLPP2 = summaryCard.penaltyCategory.equals(LPP2)).url}>
+                                        {messages("cardLinks.checkIfYouCanAppealThisPenalty")}
+                                    </a>
+                                </li>
+                            case _ =>
                         }
                     }}
                 </ul>

--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLSP.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLSP.scala.html
@@ -51,26 +51,16 @@
                 </span>
         } else {
             if(!summaryCard.isAddedOrRemovedPoint && !summaryCard.status.content.asHtml.body.contains("Expired")) {
-                if(!summaryCard.isReturnSubmitted || summaryCard.appealStatus.contains(AppealStatusEnum.Unappealable)) {
-                        <a id={s"penalty-id-${summaryCard.penaltyId}-findOutHowAppeal"} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(
-                            penaltyId = summaryCard.penaltyId,
-                           isAgent = isAgent,
-                            isFindOutHowToAppealLSP = true
-                        ).url}>
-                        {messages("cardLinks.checkIfYouCanAppealThisPenalty")}
+                summaryCard.appealStatus match {
+                    case Some(AppealStatusEnum.Rejected) if summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal) =>
+                        <a id={s"penalty-id-${summaryCard.penaltyId}-appealLink"} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyId, isAgent, is2ndStageAppeal = summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal)).url}>
+                        {messages("cardLinks.reviewAppeal", summaryCard.penaltyPoint)}
                         </a>
-                } else {
-                    summaryCard.appealStatus match {
-                        case Some(AppealStatusEnum.Rejected) if summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal) =>
-                            <a id={s"penalty-id-${summaryCard.penaltyId}-appealLink"} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyId, isAgent, is2ndStageAppeal = summaryCard.appealLevel.contains(AppealLevelEnum.FirstStageAppeal)).url}>
-                            {messages("cardLinks.reviewAppeal", summaryCard.penaltyPoint)}
-                            </a>
-                        case None =>
-                            <a id={s"penalty-id-${summaryCard.penaltyId}-appealLink"} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyId, isAgent).url}>
-                            {messages("cardLinks.appeal", summaryCard.penaltyPoint)}
-                            </a>
-                        case _ =>
-                    }
+                    case None =>
+                        <a id={s"penalty-id-${summaryCard.penaltyId}-appealLink"} class="govuk-link" href={controllers.routes.AppealsController.redirectToAppeals(summaryCard.penaltyId, isAgent).url}>
+                        {messages("cardLinks.appeal", summaryCard.penaltyPoint)}
+                        </a>
+                    case _ =>
                 }
             }
         }

--- a/test/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLSPSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesfrontend/views/components/SummaryCardLSPSpec.scala
@@ -107,11 +107,10 @@ class SummaryCardLSPSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSu
                       document.select("h3").text() shouldBe messagesForLanguage.cardTitlePoint(1)
                       document.select(s"#penalty-id-${sampleRemovedPenaltyPoint.penaltyNumber}-status").text() shouldBe penaltyStatusMessages.active
 
-                      val appealLink = document.select(s"#penalty-id-${sampleRemovedPenaltyPoint.penaltyNumber}-findOutHowAppeal")
+                      val appealLink = document.select(s"#penalty-id-${sampleRemovedPenaltyPoint.penaltyNumber}-appealLink")
                       appealLink.text() shouldBe messagesForLanguage.cardLinksFindOutHowToAppeal
                       appealLink.attr("href") shouldBe controllers.routes.AppealsController.redirectToAppeals(
-                        sampleRemovedPenaltyPoint.penaltyNumber, isAgent,
-                        isFindOutHowToAppealLSP = true
+                        sampleRemovedPenaltyPoint.penaltyNumber, isAgent
                       ).url
                     }
                   }


### PR DESCRIPTION
The rules in the view where to restrictive, whether the user has or hasn't paid there income-tax (LPP), submitted update or return (LSP), are in a TTP active period (LPP) does not matter. These rules where making it so a Check you can appeal this point was showing rather than Ask for a Review. Below are screenshots before and after fix.

LSP old
<img width="607" height="474" alt="Screenshot 2025-08-14 at 15 12 50" src="https://github.com/user-attachments/assets/79e305f9-2d7b-4831-b5c2-38af3b72954f" />

LSP new
<img width="607" height="474" alt="Screenshot 2025-08-14 at 15 20 03" src="https://github.com/user-attachments/assets/caf81ee9-d0a0-41ce-96bc-f9f458646de1" />

LPP old
<img width="607" height="376" alt="Screenshot 2025-08-14 at 13 58 32" src="https://github.com/user-attachments/assets/e342ca9d-ac44-4f47-9b6d-56d582dc5bfb" />

LPP new
<img width="607" height="376" alt="Screenshot 2025-08-14 at 13 57 26" src="https://github.com/user-attachments/assets/29d6202a-db32-4c65-b13b-e2ec59d2c9ee" />
