### PR TITLE
MIPR-2046 updated PenaltyByRow so displays when incomeTaxIsPaid and penalty is not paid

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LPPSummaryListRowHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/views/helpers/LPPSummaryListRowHelper.scala
@@ -63,12 +63,12 @@ class LPPSummaryListRowHelper extends SummaryListRowHelper with DateFormatter {
     )
 
   def payPenaltyByRow(penalty: LPPDetails)(implicit messages: Messages): Option[SummaryListRow] = {
-    val noAmountLeftToPay = penalty.penaltyAmountOutstanding.contains(0)
+    val penaltyPaid = penalty.isPaid
     val penaltyAccruing = penalty.penaltyStatus.equals(LPPPenaltyStatusEnum.Accruing)
     val penaltyAppealed = penalty.appealStatus.contains(AppealStatusEnum.Upheld)
 
     Option.unless(
-      penaltyAccruing || noAmountLeftToPay || penaltyAppealed
+      penaltyAccruing || penaltyPaid || penaltyAppealed
     ) {
       penalty.penaltyChargeDueDate.map {
         payBy =>


### PR DESCRIPTION
Note : there are changes in the test-frontend and stub also
https://github.com/hmrc/income-tax-penalties-test-frontend/pull/33
https://github.com/hmrc/income-tax-penalties-stubs/pull/39

screenshots of penalty cards following fixes 

Pay penalty By row present

<img width="613" height="364" alt="Screenshot 2025-09-26 at 09 04 38" src="https://github.com/user-attachments/assets/5afed613-e9b5-4375-9c3b-8467b212f90c" />
<img width="613" height="364" alt="Screenshot 2025-09-26 at 09 05 04" src="https://github.com/user-attachments/assets/96d74a48-5d04-4bd1-8e83-114562a789de" />

Penalty card contains Estimate tag
<img width="613" height="321" alt="Screenshot 2025-09-26 at 09 04 07" src="https://github.com/user-attachments/assets/c50b9d3b-ada1-4e1c-8038-ef3f615e58f4" />

