### PR TITLE
MIPR-2012 updated the order so cancelled penalties appear in correct place

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/IndexController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/IndexController.scala
@@ -89,17 +89,14 @@ class IndexController @Inject()(override val controllerComponents: MessagesContr
   }
 
   def sortPointsInDescendingOrder(points: Seq[LSPDetails]): Seq[LSPDetails] = {
-    val pointsWithOrder = points.zipWithIndex.map {
+    val pointsInDateOrder = points.sortWith((thisElement, nextElement) => thisElement.penaltyCreationDate.isBefore(nextElement.penaltyCreationDate))
+    val pointsWithOrder = pointsInDateOrder.zipWithIndex.map {
       case (point, idx) =>
-        val newPenaltyOrder = (point.penaltyOrder, point.penaltyStatus) match {
-          case (None, LSPPenaltyStatusEnum.Inactive) => Some("0")
-          case (None, LSPPenaltyStatusEnum.Active) => Some((idx + 1).toString)
-          case _ => point.penaltyOrder
-        }
-        point.copy(penaltyOrder = newPenaltyOrder)
+        val newPenaltyOrder = point.penaltyOrder.getOrElse((idx + 1).toString)
+        point.copy(penaltyOrder = Some(newPenaltyOrder))
     }
 
-    pointsWithOrder.sortWith((thisElement, nextElement) => thisElement.penaltyOrder.getOrElse("0").toInt > nextElement.penaltyOrder.getOrElse("0").toInt)
+    pointsWithOrder.sortWith((thisElement, nextElement) => thisElement.penaltyOrder.getOrElse("0").toInt >= nextElement.penaltyOrder.getOrElse("0").toInt)
   }
 }
 


### PR DESCRIPTION
Screenshot with position correct

<img width="306" height="881" alt="Screenshot 2025-09-29 at 17 18 39" src="https://github.com/user-attachments/assets/6a8f174f-cc7e-4de9-8133-cd373c0d8b90" />
