### PR TITLE
Fixed LPP1 and LPP2 data mixup

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/PenaltyCalculationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/PenaltyCalculationController.scala
@@ -21,10 +21,11 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.auth.actions.AuthActions
 import uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit.UserCalculationInfoAuditModel
+import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp.{LPPDetails, LPPPenaltyCategoryEnum}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.services.AuditService
 import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.TimeMachine
-import uk.gov.hmrc.incometaxpenaltiesfrontend.viewModels._
-import uk.gov.hmrc.incometaxpenaltiesfrontend.views.html._
+import uk.gov.hmrc.incometaxpenaltiesfrontend.viewModels.*
+import uk.gov.hmrc.incometaxpenaltiesfrontend.views.html.*
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import javax.inject.{Inject, Singleton}
@@ -37,6 +38,14 @@ class PenaltyCalculationController @Inject()(override val controllerComponents: 
                                              auditService: AuditService)
                                             (implicit appConfig: AppConfig, timeMachine: TimeMachine) extends FrontendBaseController with I18nSupport {
 
+  def isCorrectLPP(lpp: LPPDetails, isLPP2: Boolean): Boolean = {
+    if (isLPP2) {
+      lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP2
+    } else {
+      lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP1
+    }
+  }
+
   def penaltyCalculationPage(penaltyId: String,
                              isAgent: Boolean,
                              isLPP2: Boolean): Action[AnyContent] =
@@ -46,7 +55,7 @@ class PenaltyCalculationController @Inject()(override val controllerComponents: 
           .penaltyDetails
           .latePaymentPenalty
           .flatMap {
-            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId => lpp }
+            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId && isCorrectLPP(lpp, isLPP2) => lpp }
           }
 
         penaltyDetailsForId match {

--- a/test-fixtures/fixtures/PenaltiesDetailsTestData.scala
+++ b/test-fixtures/fixtures/PenaltiesDetailsTestData.scala
@@ -159,7 +159,7 @@ trait PenaltiesDetailsTestData extends LSPDetailsTestData with LPPDetailsTestDat
   def getPenaltyDetailsForSecondCalculationPage(secondLPPCalData: SecondLatePaymentPenaltyCalculationData): PenaltySuccessResponse = {
     val lppDetails = LPPDetails(
       principalChargeReference = principleChargeRef,
-      penaltyCategory = LPPPenaltyCategoryEnum.LPP1,
+      penaltyCategory = LPPPenaltyCategoryEnum.LPP2,
       penaltyStatus = if(secondLPPCalData.isEstimate) LPPPenaltyStatusEnum.Accruing else LPPPenaltyStatusEnum.Posted,
       penaltyAmountPaid = if(secondLPPCalData.isPenaltyPaid) Some(secondLPPCalData.penaltyAmount) else None,
       penaltyAmountPosted = if(secondLPPCalData.isEstimate) 0 else secondLPPCalData.penaltyAmount,


### PR DESCRIPTION
Bug fix where view calculation would display LPP2 data on an LPP1
now _details.collectFirst checks that for correct LPP type as well as ID