### PR TITLE
Fix supplementary calc pages redirecting due to missing penaltyCategory filter

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/SupplementaryCalculationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/SupplementaryCalculationController.scala
@@ -22,7 +22,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.auth.actions.AuthActions
 import uk.gov.hmrc.incometaxpenaltiesfrontend.models.audit.UserCalculationInfoAuditModel
-import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp.LPPDetails
+import uk.gov.hmrc.incometaxpenaltiesfrontend.models.penaltyDetails.lpp.{LPPDetails, LPPPenaltyCategoryEnum}
 import uk.gov.hmrc.incometaxpenaltiesfrontend.services.AuditService
 import uk.gov.hmrc.incometaxpenaltiesfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesfrontend.viewModels.{FirstLatePaymentPenaltyCalculationData, SecondLatePaymentPenaltyCalculationData}
@@ -49,10 +49,10 @@ class SupplementaryCalculationController @Inject()(override val controllerCompon
           .penaltyDetails
           .latePaymentPenalty
           .flatMap {
-            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId => lpp }
+            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId && lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP1 => lpp }
           }
-        
-        
+
+
         val date = timeMachine.getCurrentDate()
         val isInBreathingSpace = currentUserRequest.penaltyDetails.breathingSpace.fold(false)(_.count(bs =>
           (bs.bsStartDate.isEqual(date) || bs.bsStartDate.isBefore(date)) &&
@@ -77,7 +77,7 @@ class SupplementaryCalculationController @Inject()(override val controllerCompon
           .penaltyDetails
           .latePaymentPenalty
           .flatMap {
-            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId => lpp }
+            _.details.collectFirst { case lpp if lpp.principalChargeReference == penaltyId && lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP2 => lpp }
           }
 
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/SupplementaryCalculationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesfrontend/controllers/SupplementaryCalculationControllerISpec.scala
@@ -133,6 +133,17 @@ class SupplementaryCalculationControllerISpec extends ControllerISpecHelper
           document.getElementsByClass("govuk-summary-list__key").get(2).text() shouldBe "Penalty amount"
           document.getElementsByClass("govuk-summary-list__value").get(2).text() shouldBe "£1,001.45"
         }
+        "render LPP2 supplementary page when LPP1 appears before LPP2 in the penalty response" in {
+          stubAuthRequests(isAgent)
+          val supplementary2LPPCalcData = sampleSecondLPPCalcData()
+          stubGetPenalties(defaultNino, optArn)(OK, Json.toJson(getPenaltyDetailsWithLPP1BeforeLPP2Supplement(supplementary2LPPCalcData)))
+          val result = get(LPP2SupplementaryPath, isAgent)
+          result.status shouldBe OK
+
+          val document = Jsoup.parse(result.body)
+          document.title() shouldBe "Additional second late payment penalty calculation - Manage your Self Assessment - GOV.UK"
+          document.getH1Elements.text() shouldBe "Additional second late payment penalty calculation"
+        }
       }
     }
   }

--- a/test-fixtures/fixtures/PenaltiesDetailsTestData.scala
+++ b/test-fixtures/fixtures/PenaltiesDetailsTestData.scala
@@ -610,6 +610,82 @@ trait PenaltiesDetailsTestData extends LSPDetailsTestData with LPPDetailsTestDat
     )))
   }
 
+  def getPenaltyDetailsWithLPP1BeforeLPP2Supplement(secondLPPCalData: SecondLatePaymentPenaltyCalculationData): PenaltySuccessResponse = {
+    val lpp1Details = LPPDetails(
+      principalChargeReference = principleChargeRef,
+      penaltyCategory = LPPPenaltyCategoryEnum.LPP1,
+      penaltyStatus = LPPPenaltyStatusEnum.Posted,
+      penaltyAmountPaid = Some(400),
+      penaltyAmountPosted = 400,
+      penaltyAmountAccruing = 0,
+      penaltyAmountOutstanding = Some(0),
+      lpp1LRDays = Some("15"),
+      lpp1HRDays = Some("31"),
+      lpp2Days = None,
+      lpp1LRCalculationAmt = Some(99.99),
+      lpp1HRCalculationAmt = Some(99.99),
+      lpp2Percentage = None,
+      lpp1LRPercentage = Some(3.00),
+      lpp1HRPercentage = Some(BigDecimal(3.00).setScale(2)),
+      penaltyChargeCreationDate = Some(secondLPPCalData.payPenaltyBy.minusDays(30)),
+      communicationsDate = Some(secondLPPCalData.payPenaltyBy),
+      penaltyChargeDueDate = Some(secondLPPCalData.payPenaltyBy),
+      appealInformation = None,
+      principalChargeBillingFrom = secondLPPCalData.taxPeriodStartDate,
+      principalChargeBillingTo = secondLPPCalData.taxPeriodEndDate,
+      principalChargeDueDate = secondLPPCalData.payPenaltyBy,
+      penaltyChargeReference = Some("PEN1234567"),
+      principalChargeLatestClearing = None,
+      vatOutstandingAmount = None,
+      supplement = None,
+      metadata = LPPDetailsMetadata(principalChargeMainTr = "4700", timeToPay = None)
+    )
+    val lpp2Details = LPPDetails(
+      principalChargeReference = principleChargeRef,
+      penaltyCategory = LPPPenaltyCategoryEnum.LPP2,
+      penaltyStatus = if (secondLPPCalData.isEstimate) LPPPenaltyStatusEnum.Accruing else LPPPenaltyStatusEnum.Posted,
+      penaltyAmountPaid = if (secondLPPCalData.isPenaltyPaid) Some(secondLPPCalData.penaltyAmount) else None,
+      penaltyAmountPosted = if (secondLPPCalData.isEstimate) 0 else secondLPPCalData.penaltyAmount,
+      penaltyAmountAccruing = if (secondLPPCalData.isEstimate) secondLPPCalData.penaltyAmount else 0,
+      penaltyAmountOutstanding = if (secondLPPCalData.isPenaltyPaid) Some(0) else Some(secondLPPCalData.penaltyAmount),
+      lpp1LRDays = Some("15"),
+      lpp1HRDays = Some("31"),
+      lpp2Days = Some("31"),
+      lpp1LRCalculationAmt = Some(99.99),
+      lpp1HRCalculationAmt = Some(99.99),
+      lpp2Percentage = None,
+      lpp1LRPercentage = Some(3.00),
+      lpp1HRPercentage = Some(BigDecimal(3.00).setScale(2)),
+      penaltyChargeCreationDate = Some(secondLPPCalData.payPenaltyBy.minusDays(30)),
+      communicationsDate = Some(secondLPPCalData.payPenaltyBy),
+      penaltyChargeDueDate = Some(secondLPPCalData.payPenaltyBy),
+      appealInformation = None,
+      principalChargeBillingFrom = secondLPPCalData.taxPeriodStartDate,
+      principalChargeBillingTo = secondLPPCalData.taxPeriodEndDate,
+      principalChargeDueDate = secondLPPCalData.payPenaltyBy,
+      penaltyChargeReference = Some("PEN1234568"),
+      principalChargeLatestClearing = if (secondLPPCalData.incomeTaxIsPaid) Some(secondLPPCalData.payPenaltyBy) else None,
+      vatOutstandingAmount = None,
+      supplement = Some(true),
+      metadata = LPPDetailsMetadata(principalChargeMainTr = "4700", timeToPay = None)
+    )
+    val lpp = LatePaymentPenalty(Some(Seq(lpp1Details, lpp2Details)))
+    PenaltySuccessResponse("22/01/2023", Some(PenaltyDetails(
+      totalisations = Some(Totalisations(
+        lspTotalValue = Some(200),
+        penalisedPrincipalTotal = Some(2000),
+        lppPostedTotal = Some(165.25),
+        lppEstimatedTotal = Some(15.26),
+        totalAccountOverdue = None,
+        totalAccountPostedInterest = None,
+        totalAccountAccruingInterest = None
+      )),
+      lateSubmissionPenalty = Some(lateSubmissionPenalty),
+      latePaymentPenalty = Some(lpp),
+      breathingSpace = None
+    )))
+  }
+
   val latePaymentPenalty2: LatePaymentPenalty = LatePaymentPenalty(Some(Seq(
     sampleLPP2.copy(metadata = LPPDetailsMetadata(principalChargeMainTr = "4700", timeToPay = None))
   )))


### PR DESCRIPTION
## Problem

Both `supplementaryCalculationPage` (LPP1) and `supplementaryCalculationPageLPP2` (LPP2) were filtering penalty lookups using only `principalChargeReference`. LPP1 and LPP2 penalties for the same tax charge share the same `principalChargeReference`, so `collectFirst` picks whichever penalty appears first in the API response — regardless of category.

When the ordering had LPP2 before LPP1 (as in the `AA233330B` stub), the LPP1 supplementary route would find the LPP2 penalty (which passes `supplement.contains(true)`) but serve LPP1 view data for an LPP2 record. When LPP1 appeared first, the LPP2 supplementary route would find LPP1 (with `supplement = None`) and always redirect to home.

This explains the intermittent behaviour in QA — the ordering of penalties in the API response varies.

## Fix

Added `penaltyCategory` guard to both methods, consistent with how `PenaltyCalculationController` already does it via `isCorrectLPP(lpp, isLPP2)`:

```scala
// Before
collectFirst { case lpp if lpp.principalChargeReference == penaltyId => lpp }

// After (LPP1 route)
collectFirst { case lpp if lpp.principalChargeReference == penaltyId && lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP1 => lpp }

// After (LPP2 route)
collectFirst { case lpp if lpp.principalChargeReference == penaltyId && lpp.penaltyCategory == LPPPenaltyCategoryEnum.LPP2 => lpp }
```

## Tests

Added regression IT test: `render LPP2 supplementary page when LPP1 appears before LPP2 in the penalty response` — this test would have failed before the fix.

All tests pass: ✅ 616 unit / ✅ 339 IT (6 new)

## Note on QA data

The supplementary pages will still not appear for `AA244440A` in stub mode (it has `supplement: false`). Use `AA233330B` or `AA100001B` to test supplementary calc pages.